### PR TITLE
travis: drop sudo, off by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: php
 
 matrix:


### PR DESCRIPTION
This has been off for repositories created since 2015.

See: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments